### PR TITLE
Annotation rast fix

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,4 +26,4 @@ Imports:
     ggplot
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.1.0
+RoxygenNote: 7.1.1

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: basemapR
 Title: Base Maps For ggplot2
-Version: 0.1.0
+Version: 0.1.1
 Authors@R: 
     c(person(given = "Chris",
              family = "B",
@@ -22,7 +22,8 @@ Imports:
     jpeg,
     png,
     purrr,
-    sf
+    sf,
+    ggplot
 Encoding: UTF-8
 LazyData: true
 RoxygenNote: 7.1.0

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,7 @@ Imports:
     png,
     purrr,
     sf,
-    ggplot
+    ggplot2
 Encoding: UTF-8
 LazyData: true
 RoxygenNote: 7.1.1

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -3,6 +3,7 @@
 export(base_map)
 export(expand_bbox)
 import(sf)
+importFrom(ggplot2,annotation_raster)
 importFrom(purrr,map)
 importFrom(purrr,pmap)
 importFrom(purrr,pmap_dfr)

--- a/R/base_map.R
+++ b/R/base_map.R
@@ -11,6 +11,7 @@
 #'
 #' @import sf
 #' @importFrom purrr map pmap pmap_dfr
+#' @importFrom ggplot2 annotation_raster
 #'
 #'
 #' @examples
@@ -163,5 +164,5 @@ base_map <- function(bbox, increase_zoom = 0, basemap = "dark", nolabels = F) {
   args <- tile_positions %>%
     dplyr::mutate(raster = pngs)
 
-  return(purrr::pmap(args, annotation_raster, interpolate = TRUE))
+  return(purrr::pmap(args, ggplot2::annotation_raster, interpolate = TRUE))
 }

--- a/man/base_map.Rd
+++ b/man/base_map.Rd
@@ -29,15 +29,14 @@ bbox <- st_bbox(localauth_data)
 # add to ggplot
 library(ggplot2)
 ggplot() +
-base_map(bbox, increase_zoom = 2, basemap = 'google-terrain')+
-geom_sf(data = localauth_data, fill =NA )  +
-coord_sf(xlim = c(bbox$xmin, bbox$xmax), ylim = c(bbox$ymin, bbox$ymax), crs = 4326)
+  base_map(bbox, increase_zoom = 2, basemap = "google-terrain") +
+  geom_sf(data = localauth_data, fill = NA) +
+  coord_sf(xlim = c(bbox$xmin, bbox$xmax), ylim = c(bbox$ymin, bbox$ymax), crs = 4326)
 
 
 # add straight to ggplot
 
 ggplot() +
-base_map(st_bbox(localauth_data), increase_zoom = 2) +
-geom_sf(data = localauth_data, fill = NA)
-
+  base_map(st_bbox(localauth_data), increase_zoom = 2) +
+  geom_sf(data = localauth_data, fill = NA)
 }

--- a/man/expand_bbox.Rd
+++ b/man/expand_bbox.Rd
@@ -27,7 +27,7 @@ A function to take a bounding box (generated using st_bbox) and expand it by x m
 }
 \examples{
 library(sf)
-camden <- dplyr::filter(localauth_data, Name == 'Camden') \%>\%
+camden <- dplyr::filter(localauth_data, Name == "Camden") \%>\%
   st_transform(4326)
 bbox <- expand_bbox(st_bbox(camden), 5000, 5000)
 
@@ -35,7 +35,8 @@ library(ggplot2)
 ggplot() +
   base_map(bbox, increase_zoom = 2) +
   geom_sf(data = camden, fill = NA) +
-  coord_sf(xlim = c(bbox['xmin'], bbox['xmax']),
-           ylim = c(bbox['ymin'],bbox['ymax']),crs = 4326)
-
+  coord_sf(
+    xlim = c(bbox["xmin"], bbox["xmax"]),
+    ylim = c(bbox["ymin"], bbox["ymax"]), crs = 4326
+  )
 }


### PR DESCRIPTION
added explicit import of ggplot2::annotation_raster. Previously `base_map` failed if  ggplot2 was not loaded.